### PR TITLE
Fix: removed language notice on mobile

### DIFF
--- a/src/components/LanguageNotice.vue
+++ b/src/components/LanguageNotice.vue
@@ -51,4 +51,11 @@ button {
   cursor: pointer;
   margin-left: 10px;
 }
+
+/* dont show if is mobile */
+@media (max-width: 768px) {
+  .language-notice {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
This pull request includes a small change to the `src/components/LanguageNotice.vue` file. The change hides the language notice on mobile devices.

* [`src/components/LanguageNotice.vue`](diffhunk://#diff-51220cd074a45c798c2c15dcb8fd17de202134db1f0999c681d119c8ecb3fb07R54-R60): Added a media query to hide the `.language-notice` element on screens with a maximum width of 768px.